### PR TITLE
fix(types): inputValueProps generic

### DIFF
--- a/src/semantic/textfield/types.ts
+++ b/src/semantic/textfield/types.ts
@@ -11,7 +11,7 @@ import type {
 
 export interface TextFieldBaseProps
   extends InputBaseProps,
-    InputValueProps<string | number>,
+    InputValueProps<string | ReadonlyArray<string> | number>,
     DOMProps,
     FocusableDOMProps,
     KeyboardEventProps,

--- a/src/semantic/textfield/useAutoResize.ts
+++ b/src/semantic/textfield/useAutoResize.ts
@@ -2,7 +2,8 @@ import { RefObject, useLayoutEffect } from 'react'
 
 import type { InputValueProps } from '../../shared/types/input'
 
-export interface UseAutoResizeProps extends InputValueProps<string | number> {
+export interface UseAutoResizeProps
+  extends InputValueProps<string | ReadonlyArray<string> | number> {
   /**
    * Enable auto resize.
    */


### PR DESCRIPTION
modify generic used at InputValueProps to better compatibility with react input & text area props



textarea value prop: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9281c8a76386ffb67aa69264b4242e6e42f981f8/types/react/v17/index.d.ts#L2413

input value prop:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9281c8a76386ffb67aa69264b4242e6e42f981f8/types/react/v17/index.d.ts#L2215